### PR TITLE
Updated HTML-AutoCloseTag Bundle Link

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,7 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
+            Bundle 'vim-scripts/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
The original one from amirh is no longer working, and git asks you for your username/password, and fails after that. Using the one from the vim-scripts repo instead.